### PR TITLE
docs: Update README to TestMu AI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,82 @@
-# npm Plugin For TestCafe Integration With LambdaTest HyperExecute
+# Run TestCafe on HyperExecute on TestMu AI (Formerly LambdaTest)
 
-[![Testcafe Health Check](https://github.com/LambdaTest/testcafe-browser-provider-hyperexecute/actions/workflows/main.yml/badge.svg)](https://github.com/LambdaTest/testcafe-browser-provider-hyperexecute/actions/workflows/main.yml)
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://github.com/LambdaTest/testcafe-browser-provider-hyperexecute/actions/workflows/main.yml"><img src="https://img.shields.io/github/actions/workflow/status/LambdaTest/testcafe-browser-provider-hyperexecute/main.yml?style=for-the-badge&labelColor=000000&label=Health%20Check" alt="Testcafe Health Check"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
 
-This plugin integrates [TestCafe](http://devexpress.github.io/testcafe) with the [LambdaTest HyperExecute Testing Cloud](https://www.lambdatest.com/hyperexecute/).
+## Getting Started
 
-## Install
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-```sh
-$ npm install testcafe-browser-provider-hyperexecute
+With TestMu AI (Formerly LambdaTest), you can run TestCafe tests on the HyperExecute testing cloud across real browsers and operating systems. This sample shows how to configure the TestCafe HyperExecute browser provider plugin to run on the TestMu AI cloud.
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (LTS version recommended) and npm
+- [TestCafe](https://devexpress.github.io/testcafe/) installed
+- A TestMu AI (Formerly LambdaTest) account — [sign up here](https://www.testmuai.com/register/)
+
+### Setup
+
+Clone the repository:
+
+```bash
+git clone https://github.com/LambdaTest/testcafe-browser-provider-hyperexecute.git
+cd testcafe-browser-provider-hyperexecute
 ```
 
-## Usage
-Before using this plugin, save the LambdaTest username and access key to environment variables `LT_USERNAME` and `LT_ACCESS_KEY`, as described in [LambdaTest Documentation](https://www.lambdatest.com/support/docs/using-environment-variables-for-authentication-credentials).
+Install the plugin:
 
-You can determine the available browser aliases by running
-
-```sh
-$ testcafe -b hyperexecute
+```bash
+npm install testcafe-browser-provider-hyperexecute
 ```
 
-If you run tests from the command line, use the browser alias when specifying browsers:
-For Single Configuration
+Set your TestMu AI credentials as environment variables:
 
-```sh
-$ testcafe "hyperexecute:Chrome@74.0:Windows 8" "path/to/test/file.js"
+**Linux/macOS:**
+```bash
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
 
-For Parallel/Multiple Configuration
-
-```sh
-$ testcafe "hyperexecute:Chrome@74.0:Windows 8","hyperexecute:Chrome@75.0:Windows 10" "path/to/test/file.js"
+**Windows:**
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
 
-For Real Devices
-```sh
-$ testcafe "hyperexecute:Galaxy S8@9:android:isReal" "path/to/test/file.js"
+List available browser aliases:
+
+```bash
+testcafe -b hyperexecute
 ```
 
+### Run tests
 
+Run tests on a single configuration:
+
+```bash
+testcafe "hyperexecute:Chrome@74.0:Windows 8" "path/to/test/file.js"
 ```
-Not valid for real Devices: ---
-                              v
+
+Run on multiple configurations in parallel:
+
+```bash
+testcafe "hyperexecute:Chrome@74.0:Windows 8","hyperexecute:Chrome@75.0:Windows 10" "path/to/test/file.js"
 ```
-When you use API, pass the alias to the `browsers()` method:
+
+Run on real devices:
+
+```bash
+testcafe "hyperexecute:Galaxy S8@9:android:isReal" "path/to/test/file.js"
+```
+
+Use the API:
 
 ```js
 testCafe
@@ -52,84 +86,74 @@ testCafe
     .run();
 ```
 
-## Build Plugin Locally (Development Mode)
+Optional configuration via environment variables:
 
-1.  Clone this repository,
-2.  Rename Project
-```sh
-$ mv testcafe-browser-provider-hyperexecute hyperexecute
-```
-3. Go to the project path
-```sh
-$ cd hyperexecute
-```
-4. Install Packages and Build
-```sh
-$ npm i
-$ npm run build
-```
-5. Link Testcafe with hyperexecute
-```sh
-$ sudo npm link
-```
-6. [See this for Credentials](#usage)
-
-## Configuration
-
-Use the following environment variables to set additional configuration options:
-
- - `LT_TEST_NAME` - Test name on LambdaTest.
- - `LT_BUILD` - Build name on LambdaTest.
- - `LT_CAPABILITY_PATH` - Path to a file which contains additional capability options as JSON file (eg. config.json)
-
-    ```js
-    {
-        "Chrome@63.0:Windows 8.1": {
-            "network": true,
-            "visual": true,
-            "timezone": "UTC+11:00"
-        }
-    }
-    ```
-    - `Chrome@63.0:Windows 8.1` is browser alias.
- - `LT_RESOLUTION` - allows setting the screen resolution for desktop browsers in the `${width}x${height}` format.
- - `LT_VERBOSE` - true or false.
- - `LT_W3C` - true or false.
- - `LT_ENABLE_TRACE` - true or false.
- - `LT_PROXY_HOST` - Hostname/IP of proxy, this is a mandatory value.
- - `LT_PROXY_PORT` - Port for the proxy, by default it would consider 3128 if proxyhost is used For Basic Authentication, we use the below proxy options.
- - `LT_PROXY_USER` - Username for connecting to proxy, mandatory value for using 'proxypass'.
- - `LT_PROXY_PASS` - Password for the USERNAME option.
- - `LT_DIR` - Path of the local folder you want to test.
- - `LT_SELENIUM_VERSION` - Browser specific capability (Not for Real Devices)
- - `LT_APPIUM_VERSION` - Real Device specific capability
- - `LT_CONSOLE` - true or false.
- - `LT_NETWORK` - true or false.
- - `LT_VIDEO` - true or false.
- - `LT_SCREENSHOT` - true or false.
- - `LT_TIMEZONE` - Configure tests to run on a custom time zone. (Not for Real Devices)
+- `LT_TEST_NAME` - Test name on TestMu AI
+- `LT_BUILD` - Build name
+- `LT_CAPABILITY_PATH` - Path to a JSON file with additional capabilities
+- `LT_RESOLUTION` - Screen resolution in `${width}x${height}` format
+- `LT_VERBOSE` - true or false
+- `LT_PROXY_HOST` / `LT_PROXY_PORT` / `LT_PROXY_USER` / `LT_PROXY_PASS` - Proxy settings
+- `LT_CONSOLE` / `LT_NETWORK` / `LT_VIDEO` / `LT_SCREENSHOT` - Logging options
 
 Example:
 
-```sh
+```bash
 export LT_RESOLUTION="1920x1080"
 export LT_TEST_NAME="Test TestCafe"
 export LT_BUILD="Build x"
 testcafe "hyperexecute:Chrome","hyperexecute:Chrome@74.0:Windows 8" tests/
 ```
 
-```
-LT_TIMEZONE
-LT_SELENIUM_VERSION
-LT_RESOLUTION
+### Local testing with TestMu AI Tunnel
 
-Above are not valid for real devices
-```
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-## About LambdaTest
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-[LambdaTest](https://www.lambdatest.com/) is a cloud based selenium grid infrastructure that can help you run automated cross browser compatibility tests on 2000+ different browser and operating system environments. LambdaTest supports all programming languages and frameworks that are supported with Selenium, and have easy integrations with all popular CI/CD platforms. It's a perfect solution to bring your [selenium automation testing](https://www.lambdatest.com/selenium-automation) to cloud based infrastructure that not only helps you increase your test coverage over multiple desktop and mobile browsers, but also allows you to cut down your test execution time by running tests on parallel.
+Use `LT_DIR` to set the path of the local folder you want to test through the tunnel.
 
-## License
+## Contributions
 
-Licensed under the [MIT license](./LICENSE).
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Angular CLI version.
+
+## TestMu AI (Formerly LambdaTest) Community
+
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
+
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
+
+## Learning Resources by TestMu AI (Formerly LambdaTest)
+
+Learn modern testing through tutorials, guides, videos, and weekly updates:
+
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
+
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
+
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
+
+ð Find the new home for [LambdaTest](https://www.testmuai.com).
+
+### How LambdaTest Evolved into TestMu AI
+
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
+
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
+
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
+
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+## Support
+
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.


### PR DESCRIPTION
Updates README to follow the standard TestMu AI (Formerly LambdaTest) template with updated branding and structure.