### PR TITLE
docs: update README branding from LambdaTest to TestMu AI (Formerly LambdaTest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# npm Plugin For TestCafe Integration With LambdaTest HyperExecute
+# npm Plugin For TestCafe Integration With TestMu AI HyperExecute
 
 [![Testcafe Health Check](https://github.com/LambdaTest/testcafe-browser-provider-hyperexecute/actions/workflows/main.yml/badge.svg)](https://github.com/LambdaTest/testcafe-browser-provider-hyperexecute/actions/workflows/main.yml)
 
-This plugin integrates [TestCafe](http://devexpress.github.io/testcafe) with the [LambdaTest HyperExecute Testing Cloud](https://www.lambdatest.com/hyperexecute/).
+This plugin integrates [TestCafe](http://devexpress.github.io/testcafe) with the TestMu AI (Formerly LambdaTest) HyperExecute Testing Cloud.
 
 ## Install
 
@@ -11,7 +11,7 @@ $ npm install testcafe-browser-provider-hyperexecute
 ```
 
 ## Usage
-Before using this plugin, save the LambdaTest username and access key to environment variables `LT_USERNAME` and `LT_ACCESS_KEY`, as described in [LambdaTest Documentation](https://www.lambdatest.com/support/docs/using-environment-variables-for-authentication-credentials).
+Before using this plugin, save the TestMu AI (Formerly LambdaTest) username and access key to environment variables `LT_USERNAME` and `LT_ACCESS_KEY`, as described in TestMu AI (Formerly LambdaTest) Documentation.
 
 You can determine the available browser aliases by running
 
@@ -126,9 +126,9 @@ LT_RESOLUTION
 Above are not valid for real devices
 ```
 
-## About LambdaTest
+## About TestMu AI (Formerly LambdaTest)
 
-[LambdaTest](https://www.lambdatest.com/) is a cloud based selenium grid infrastructure that can help you run automated cross browser compatibility tests on 2000+ different browser and operating system environments. LambdaTest supports all programming languages and frameworks that are supported with Selenium, and have easy integrations with all popular CI/CD platforms. It's a perfect solution to bring your [selenium automation testing](https://www.lambdatest.com/selenium-automation) to cloud based infrastructure that not only helps you increase your test coverage over multiple desktop and mobile browsers, but also allows you to cut down your test execution time by running tests on parallel.
+TestMu AI (Formerly LambdaTest) is a cloud based selenium grid infrastructure that can help you run automated cross browser compatibility tests on 2000+ different browser and operating system environments. TestMu AI (Formerly LambdaTest) supports all programming languages and frameworks that are supported with Selenium, and have easy integrations with all popular CI/CD platforms. It's a perfect solution to bring your selenium automation testing to cloud based infrastructure that not only helps you increase your test coverage over multiple desktop and mobile browsers, but also allows you to cut down your test execution time by running tests on parallel.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Fix H1 title: replace LambdaTest with TestMu AI in the heading
- Replace standalone LambdaTest references in body text with TestMu AI (Formerly LambdaTest)
- Strip lambdatest.com hyperlinks (replace with plain link text)
- Update About LambdaTest section heading and body to TestMu AI (Formerly LambdaTest)

Supersedes PR #7 which could not be merged due to branch protection rules requiring an approving review.

Generated with Claude Code